### PR TITLE
updated the id lookups to strip quotes

### DIFF
--- a/includes/export_functions.php
+++ b/includes/export_functions.php
@@ -301,7 +301,7 @@ function exportEventFrames( $event, $exportDetail, $exportImages )
 {
     global $SLANG;
 
-    $sql = "select *, unix_timestamp( TimeStamp ) as UnixTimeStamp from Frames where EventID = '".dbEscape($event['Id'])."' order by FrameId";
+    $sql = "select *, unix_timestamp( TimeStamp ) as UnixTimeStamp from Frames where EventID = ".dbEscape($event['Id'])." order by FrameId";
     $frames = dbFetchAll( $sql );
 
     ob_start();
@@ -777,7 +777,7 @@ function exportEventImagesMaster( $eids )
 <?php
 	foreach ($eids as $eid) {
 		//get monitor id and event id
-		$sql = "select E.MonitorId from Monitors as M inner join Events as E on (M.Id = E.MonitorId) where E.Id = '".dbEscape($eid)."'";
+		$sql = "select E.MonitorId from Monitors as M inner join Events as E on (M.Id = E.MonitorId) where E.Id = ".dbEscape($eid)."";
 		$event = dbFetchOne( $sql );
 		$eventMonitorId[$eid] = $event['MonitorId'];
 	}
@@ -938,7 +938,7 @@ function exportFileList( $eid, $exportDetail, $exportFrames, $exportImages, $exp
 
     if ( canView( 'Events' ) && $eid )
     {
-        $sql = "select E.Id,E.MonitorId,M.Name As MonitorName,M.Width,M.Height,E.Name,E.Cause,E.Notes,E.StartTime,E.Length,E.Frames,E.AlarmFrames,E.TotScore,E.AvgScore,E.MaxScore,E.Archived from Monitors as M inner join Events as E on (M.Id = E.MonitorId) where E.Id = '".dbEscape($eid)."'";
+        $sql = "select E.Id,E.MonitorId,M.Name As MonitorName,M.Width,M.Height,E.Name,E.Cause,E.Notes,E.StartTime,E.Length,E.Frames,E.AlarmFrames,E.TotScore,E.AvgScore,E.MaxScore,E.Archived from Monitors as M inner join Events as E on (M.Id = E.MonitorId) where E.Id = ".dbEscape($eid);
         $event = dbFetchOne( $sql );
 		$eventPath =  mygetEventPath( $event );
         $files = array();

--- a/views/arc-console.php
+++ b/views/arc-console.php
@@ -57,11 +57,11 @@ $filterQuery = $_REQUEST['filter']['query'];
 $running = daemonCheck();
 $status = $running?$SLANG['Running']:$SLANG['Stopped'];
 
-if ( $group = dbFetchOne( "select * from Groups where Id = '".(empty($_COOKIE['zmGroup'])?0:dbEscape($_COOKIE['zmGroup']))."'" ) )
+if ( $group = dbFetchOne( "select * from Groups where Id = ".(empty($_COOKIE['zmGroup'])?0:dbEscape($_COOKIE['zmGroup']))."" ) )
     $groupIds = array_flip(explode( ',', $group['MonitorIds'] ));
 
 $sqlQuery = "SELECT * FROM Monitors";
-$sqlQuery .= " WHERE Function IN ( 'Modect', 'Monitor' ) AND Enabled";
+$sqlQuery .= " WHERE Function IN ( 'Modect', 'Monitor' , 'Mocord') AND Enabled";
 $sqlQuery .= " ORDER BY Sequence ASC";
 
 $monitors = dbFetchAll( $sqlQuery );

--- a/views/arc-event.php
+++ b/views/arc-event.php
@@ -38,7 +38,7 @@ if ( $user['MonitorIds'] )
 else
     $midSql = '';
 
-$sql = "select E.*,M.Name as MonitorName,M.Width,M.Height,M.DefaultRate,M.DefaultScale from Events as E inner join Monitors as M on E.MonitorId = M.Id where E.Id = '".dbEscape($eid)."'".$midSql;
+$sql = "select E.*,M.Name as MonitorName,M.Width,M.Height,M.DefaultRate,M.DefaultScale from Events as E inner join Monitors as M on E.MonitorId = M.Id WHERE E.Id = ".dbEscape($eid)." ".$midSql;
 $event = dbFetchOne( $sql );
 
 if ( isset( $_REQUEST['rate'] ) )

--- a/views/arc-watch.php
+++ b/views/arc-watch.php
@@ -32,7 +32,7 @@ if ( !canView( 'Stream' ) )
     return;
 }
 
-$sql = "select C.*, M.* from Monitors as M left join Controls as C on (M.ControlId = C.Id ) where M.Id = '".dbEscape($_REQUEST['mid'])."'";
+$sql = "select C.*, M.* from Monitors as M left join Controls as C on (M.ControlId = C.Id ) where M.Id = ".dbEscape($_REQUEST['mid'])."";
 $monitor = dbFetchOne( $sql );
 
 if ( isset( $_REQUEST['scale'] ) )


### PR DESCRIPTION
newer zone-minder uses numerical number for lookup and mysql will throw error if it's looking up through 'text'

added mocord cause it's also a monitor mode (which i think is also new)